### PR TITLE
[TASK] Allow `CacheService` usage in external unit tests 

### DIFF
--- a/Classes/ConfigurationObjectFactory.php
+++ b/Classes/ConfigurationObjectFactory.php
@@ -126,7 +126,7 @@ class ConfigurationObjectFactory implements SingletonInterface
     protected function register($className)
     {
         if (false === isset($this->configurationObjectServiceFactory[$className])) {
-            if (false === Core::classExists($className)) {
+            if (false === Core::get()->classExists($className)) {
                 throw new ClassNotFoundException(
                     'Trying to get a non-existing configuration object: "' . $className . '".',
                     1448886437
@@ -164,7 +164,7 @@ class ConfigurationObjectFactory implements SingletonInterface
      */
     protected function getConfigurationObjectMapper()
     {
-        return Core::getObjectManager()->get(ConfigurationObjectMapper::class);
+        return Core::get()->getObjectManager()->get(ConfigurationObjectMapper::class);
     }
 
     /**

--- a/Classes/ConfigurationObjectInstance.php
+++ b/Classes/ConfigurationObjectInstance.php
@@ -133,7 +133,7 @@ class ConfigurationObjectInstance
      */
     public function refreshValidationResult()
     {
-        $validator = Core::getValidatorResolver()
+        $validator = Core::get()->getValidatorResolver()
             ->getBaseValidatorConjunctionWithMixedTypesCheck(get_class($this->object));
 
         $this->validationResult = $validator->validate($this->object);

--- a/Classes/ConfigurationObjectMapper.php
+++ b/Classes/ConfigurationObjectMapper.php
@@ -114,7 +114,7 @@ class ConfigurationObjectMapper extends PropertyMapper
         $typeConverter = $this->getTypeConverter($source, $targetType, $configuration);
         $targetType = ltrim($typeConverter->getTargetTypeForSource($source, $targetType), '\\');
 
-        if (Core::classExists($targetType)) {
+        if (Core::get()->classExists($targetType)) {
             $source = $this->handleDataPreProcessor($source, $targetType, $currentPropertyPath);
             $targetType = $this->handleMixedType($source, $targetType, $currentPropertyPath);
 
@@ -291,7 +291,7 @@ class ConfigurationObjectMapper extends PropertyMapper
     protected function getProperties($targetType)
     {
         if (false === isset($this->typeProperties[$targetType])) {
-            $this->typeProperties[$targetType] = (Core::classExists($targetType)) ?
+            $this->typeProperties[$targetType] = (Core::get()->classExists($targetType)) ?
                 $this->reflectionService->getClassSchema($targetType)->getProperties() :
                 null;
         }

--- a/Classes/Core/Core.php
+++ b/Classes/Core/Core.php
@@ -15,6 +15,7 @@ namespace Romm\ConfigurationObject\Core;
 
 use Romm\ConfigurationObject\Exceptions\MethodNotFoundException;
 use Romm\ConfigurationObject\Service\Items\Parents\ParentsUtility;
+use Romm\ConfigurationObject\Service\ServiceFactory;
 use Romm\ConfigurationObject\Validation\ValidatorResolver;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -26,6 +27,8 @@ use TYPO3\CMS\Extbase\Reflection\ReflectionService;
 
 /**
  * General functions.
+ *
+ * The structure is here to help unit tests to mock correctly what is needed.
  */
 class Core implements SingletonInterface
 {
@@ -163,6 +166,14 @@ class Core implements SingletonInterface
         }
 
         return $flag;
+    }
+
+    /**
+     * @return ServiceFactory
+     */
+    public function getServiceFactoryInstance()
+    {
+        return GeneralUtility::makeInstance(ServiceFactory::class);
     }
 
     /**

--- a/Classes/Core/Core.php
+++ b/Classes/Core/Core.php
@@ -16,6 +16,7 @@ namespace Romm\ConfigurationObject\Core;
 use Romm\ConfigurationObject\Exceptions\MethodNotFoundException;
 use Romm\ConfigurationObject\Service\Items\Parents\ParentsUtility;
 use Romm\ConfigurationObject\Validation\ValidatorResolver;
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -42,6 +43,11 @@ class Core implements SingletonInterface
      * @var ValidatorResolver
      */
     protected static $validatorResolver;
+
+    /**
+     * @var CacheManager
+     */
+    protected static $cacheManager;
 
     /**
      * @var ParentsUtility
@@ -92,6 +98,18 @@ class Core implements SingletonInterface
         }
 
         return self::$validatorResolver;
+    }
+
+    /**
+     * @return CacheManager
+     */
+    public static function getCacheManager()
+    {
+        if (null === self::$cacheManager) {
+            self::$cacheManager = self::getObjectManager()->get(CacheManager::class);
+        }
+
+        return self::$cacheManager;
     }
 
     /**

--- a/Classes/Service/AbstractService.php
+++ b/Classes/Service/AbstractService.php
@@ -13,6 +13,7 @@
 
 namespace Romm\ConfigurationObject\Service;
 
+use Romm\ConfigurationObject\Core\Core;
 use Romm\ConfigurationObject\Exceptions\InvalidServiceOptionsException;
 use Romm\ConfigurationObject\Exceptions\InvalidTypeException;
 use Romm\ConfigurationObject\Service\DataTransferObject\AbstractServiceDTO;
@@ -69,6 +70,7 @@ abstract class AbstractService implements ServiceInterface
      */
     final public function initializeObject(array $options = [])
     {
+        $this->objectManager = Core::getObjectManager();
         $this->checkUnknownOptions($options);
         $this->checkRequiredOptions($options);
         $this->options = $this->fillOptionsWithValues($options);
@@ -200,13 +202,5 @@ abstract class AbstractService implements ServiceInterface
         }
 
         static::$delayedCallbacks = [];
-    }
-
-    /**
-     * @param ObjectManagerInterface $objectManager
-     */
-    public function injectObjectManager(ObjectManagerInterface $objectManager)
-    {
-        $this->objectManager = $objectManager;
     }
 }

--- a/Classes/Service/AbstractService.php
+++ b/Classes/Service/AbstractService.php
@@ -70,7 +70,7 @@ abstract class AbstractService implements ServiceInterface
      */
     final public function initializeObject(array $options = [])
     {
-        $this->objectManager = Core::getObjectManager();
+        $this->objectManager = Core::get()->getObjectManager();
         $this->checkUnknownOptions($options);
         $this->checkRequiredOptions($options);
         $this->options = $this->fillOptionsWithValues($options);

--- a/Classes/Service/DataTransferObject/AbstractServiceDTO.php
+++ b/Classes/Service/DataTransferObject/AbstractServiceDTO.php
@@ -63,7 +63,7 @@ abstract class AbstractServiceDTO
      */
     protected function setConfigurationObjectClassName($className)
     {
-        if (false === Core::classExists($className)) {
+        if (false === Core::get()->classExists($className)) {
             throw new ClassNotFoundException('The class "' . $className . '" does not exist.', 1456002532);
         }
         if (false === is_subclass_of($className, ConfigurationObjectInterface::class)) {

--- a/Classes/Service/Items/Cache/CacheService.php
+++ b/Classes/Service/Items/Cache/CacheService.php
@@ -14,6 +14,7 @@
 namespace Romm\ConfigurationObject\Service\Items\Cache;
 
 use Romm\ConfigurationObject\ConfigurationObjectInstance;
+use Romm\ConfigurationObject\Core\Core;
 use Romm\ConfigurationObject\Service\DataTransferObject\GetConfigurationObjectDTO;
 use Romm\ConfigurationObject\Service\AbstractService;
 use Romm\ConfigurationObject\Service\Event\ConfigurationObjectAfterServiceEventInterface;
@@ -233,18 +234,6 @@ class CacheService extends AbstractService implements ConfigurationObjectBeforeS
     }
 
     /**
-     * @return CacheManager
-     */
-    protected function getCacheManager()
-    {
-        if (null === self::$cacheManager) {
-            self::$cacheManager = $this->objectManager->get(CacheManager::class);
-        }
-
-        return self::$cacheManager;
-    }
-
-    /**
      * Returns the cache instance of this service.
      *
      * @return FrontendInterface
@@ -253,5 +242,13 @@ class CacheService extends AbstractService implements ConfigurationObjectBeforeS
     {
         return $this->getCacheManager()
             ->getCache($this->cacheIdentifier);
+    }
+
+    /**
+     * @return CacheManager
+     */
+    public function getCacheManager()
+    {
+        return Core::getCacheManager();
     }
 }

--- a/Classes/Service/Items/Cache/CacheService.php
+++ b/Classes/Service/Items/Cache/CacheService.php
@@ -249,6 +249,6 @@ class CacheService extends AbstractService implements ConfigurationObjectBeforeS
      */
     public function getCacheManager()
     {
-        return Core::getCacheManager();
+        return Core::get()->getCacheManager();
     }
 }

--- a/Classes/Service/Items/Parents/ParentsService.php
+++ b/Classes/Service/Items/Parents/ParentsService.php
@@ -58,7 +58,7 @@ class ParentsService extends AbstractService implements ObjectConversionAfterSer
         $result = $serviceDataTransferObject->getResult();
 
         if (is_object($result)) {
-            foreach (Core::getGettablePropertiesOfObject($result) as $propertyName) {
+            foreach (Core::get()->getGettablePropertiesOfObject($result) as $propertyName) {
                 $property = ObjectAccess::getProperty($result, $propertyName);
 
                 $this->checkProperty($serviceDataTransferObject, $property, $propertyName);
@@ -102,7 +102,7 @@ class ParentsService extends AbstractService implements ObjectConversionAfterSer
                 : '';
             $path .= $pathSuffix;
 
-            if (true === Core::getParentsUtility()->classUsesParentsTrait($property)) {
+            if (true === Core::get()->getParentsUtility()->classUsesParentsTrait($property)) {
                 $this->objectsWithParentsPaths[$path] = $path;
             }
         }
@@ -163,7 +163,7 @@ class ParentsService extends AbstractService implements ObjectConversionAfterSer
 
         if (1 === count($path)) {
             if (is_object($propertyValue)
-                && Core::getParentsUtility()->classUsesParentsTrait($propertyValue)
+                && Core::get()->getParentsUtility()->classUsesParentsTrait($propertyValue)
             ) {
                 /** @var ParentsTrait $propertyValue */
                 $propertyValue->setParents($parents);

--- a/Classes/Service/Items/Parents/ParentsTrait.php
+++ b/Classes/Service/Items/Parents/ParentsTrait.php
@@ -66,7 +66,7 @@ trait ParentsTrait
 
         // Then, we check each parent's parents.
         foreach ($this->_parents as $parent) {
-            if (Core::getParentsUtility()->classUsesParentsTrait($parent)) {
+            if (Core::get()->getParentsUtility()->classUsesParentsTrait($parent)) {
                 /** @var ParentsTrait $parent */
                 return $parent->withFirstParent($parentClassName, $callBack, $notFoundCallBack);
             }

--- a/Classes/Service/Items/Persistence/PersistenceService.php
+++ b/Classes/Service/Items/Persistence/PersistenceService.php
@@ -81,7 +81,7 @@ class PersistenceService extends AbstractService implements ObjectConversionBefo
      */
     public function objectConversionBefore(ConfigurationObjectConversionDTO $serviceDataTransferObject)
     {
-        if (Core::classExists($serviceDataTransferObject->getTargetType())
+        if (Core::get()->classExists($serviceDataTransferObject->getTargetType())
             && in_array(DomainObjectInterface::class, class_implements($serviceDataTransferObject->getTargetType()))
         ) {
             $serviceDataTransferObject->setResult($serviceDataTransferObject->getSource());

--- a/Classes/Service/ServiceFactory.php
+++ b/Classes/Service/ServiceFactory.php
@@ -259,9 +259,9 @@ class ServiceFactory
         $flag = false;
         $serviceInstance = null;
 
-        if (Core::classExists($className)) {
+        if (Core::get()->classExists($className)) {
             /** @var AbstractService $serviceInstance */
-            $serviceInstance = Core::getObjectManager()->get($className);
+            $serviceInstance = Core::get()->getObjectManager()->get($className);
 
             if ($serviceInstance instanceof AbstractService) {
                 $serviceInstance->initializeObject($options);

--- a/Classes/Service/ServiceFactory.php
+++ b/Classes/Service/ServiceFactory.php
@@ -97,7 +97,7 @@ class ServiceFactory
      */
     public static function getInstance()
     {
-        return GeneralUtility::makeInstance(self::class);
+        return Core::get()->getServiceFactoryInstance();
     }
 
     /**
@@ -241,10 +241,9 @@ class ServiceFactory
         $this->hasBeenInitialized = true;
 
         foreach ($this->service as $service) {
-            $serviceClassName = $service['className'];
-            $serviceOptions = $service['options'];
+            list($serviceClassName,  $serviceOptions) = $this->manageServiceData($service);
 
-            $this->serviceInstances[$serviceClassName] = $this->createServiceInstance($serviceClassName, $serviceOptions);
+            $this->serviceInstances[$serviceClassName] = $this->getServiceInstance($serviceClassName, $serviceOptions);
         }
     }
 
@@ -254,7 +253,7 @@ class ServiceFactory
      * @return AbstractService
      * @throws WrongInheritanceException
      */
-    protected function createServiceInstance($className, array $options)
+    protected function getServiceInstance($className, array $options)
     {
         $flag = false;
         $serviceInstance = null;
@@ -377,6 +376,18 @@ class ServiceFactory
         }
 
         return $this->servicesEvents[$serviceEvent];
+    }
+
+    /**
+     * This function is here to allow unit tests to override data.
+     *
+     * @param array $service
+     * @return array
+     * @internal
+     */
+    protected function manageServiceData(array $service)
+    {
+        return [$service['className'], $service['options']];
     }
 
     /**

--- a/Classes/Traits/ConfigurationObject/ArrayConversionTrait.php
+++ b/Classes/Traits/ConfigurationObject/ArrayConversionTrait.php
@@ -76,7 +76,7 @@ trait ArrayConversionTrait
      */
     private function getObjectPropertiesValues($object)
     {
-        $properties = Core::getGettablePropertiesOfObject($object);
+        $properties = Core::get()->getGettablePropertiesOfObject($object);
         $finalProperties = [];
 
         foreach ($properties as $property) {

--- a/Classes/TypeConverter/ConfigurationObjectConverter.php
+++ b/Classes/TypeConverter/ConfigurationObjectConverter.php
@@ -33,7 +33,7 @@ class ConfigurationObjectConverter extends ObjectConverter
     {
         $specificTargetType = $this->objectContainer->getImplementationClassName($targetType);
 
-        if (Core::classExists($specificTargetType)) {
+        if (Core::get()->classExists($specificTargetType)) {
             $propertyTags = $this->reflectionService->getPropertyTagValues($specificTargetType, $propertyName, 'var');
 
             if (!empty($propertyTags)) {

--- a/Classes/Validation/Validator/ClassExistsValidator.php
+++ b/Classes/Validation/Validator/ClassExistsValidator.php
@@ -27,7 +27,7 @@ class ClassExistsValidator extends AbstractValidator implements SingletonInterfa
      */
     public function isValid($value)
     {
-        if (false === Core::classExists($value)) {
+        if (false === Core::get()->classExists($value)) {
             $errorMessage = $this->translateErrorMessage('validator.class_exists.not_valid', 'configuration_object', [$value]);
             $this->addError($errorMessage, 1457610460);
         }

--- a/Classes/Validation/Validator/Internal/MixedTypeCollectionValidator.php
+++ b/Classes/Validation/Validator/Internal/MixedTypeCollectionValidator.php
@@ -29,7 +29,7 @@ class MixedTypeCollectionValidator extends CollectionValidator
     public function isValid($value)
     {
         foreach ($value as $index => $collectionElement) {
-            $collectionElementValidator = Core::getValidatorResolver()
+            $collectionElementValidator = Core::get()->getValidatorResolver()
                 ->getBaseValidatorConjunctionWithMixedTypesCheck(get_class($collectionElement));
 
             $this->result->forProperty($index)->merge($collectionElementValidator->validate($collectionElement));

--- a/Classes/Validation/Validator/Internal/MixedTypeObjectValidator.php
+++ b/Classes/Validation/Validator/Internal/MixedTypeObjectValidator.php
@@ -32,7 +32,7 @@ class MixedTypeObjectValidator extends AbstractValidator
      */
     protected function isValid($value)
     {
-        $validatorResolver = Core::getValidatorResolver();
+        $validatorResolver = Core::get()->getValidatorResolver();
         $genericObjectValidator = $validatorResolver->getBaseValidatorConjunction(get_class($value));
 
         $this->result->merge($genericObjectValidator->validate($value));

--- a/Tests/Unit/AbstractUnitTest.php
+++ b/Tests/Unit/AbstractUnitTest.php
@@ -1,0 +1,14 @@
+<?php
+namespace Romm\ConfigurationObject\Tests\Unit;
+
+use TYPO3\CMS\Core\Tests\UnitTestCase;
+
+abstract class AbstractUnitTest extends UnitTestCase
+{
+    use ConfigurationObjectUnitTestUtility;
+
+    protected function setUp()
+    {
+        $this->setUpConfigurationObjectCore();
+    }
+}

--- a/Tests/Unit/ConfigurationObjectFactoryTest.php
+++ b/Tests/Unit/ConfigurationObjectFactoryTest.php
@@ -13,12 +13,9 @@ use Romm\ConfigurationObject\Tests\Fixture\Company\Company;
 use Romm\ConfigurationObject\Tests\Fixture\Company\Employee;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithWrongServiceFactory;
 use Romm\ConfigurationObject\Tests\Fixture\Validator\WrongValueValidator;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
 
-class ConfigurationObjectFactoryTest extends UnitTestCase
+class ConfigurationObjectFactoryTest extends AbstractUnitTest
 {
-
-    use ConfigurationObjectUnitTestUtility;
 
     /**
      * @var Company
@@ -46,6 +43,8 @@ class ConfigurationObjectFactoryTest extends UnitTestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         $this->initializeConfigurationObjectTestServices();
     }
 

--- a/Tests/Unit/ConfigurationObjectFactoryTest.php
+++ b/Tests/Unit/ConfigurationObjectFactoryTest.php
@@ -111,7 +111,7 @@ class ConfigurationObjectFactoryTest extends AbstractUnitTest
         $companyObject = ConfigurationObjectFactory::getInstance()
             ->get(Company::class, $this->defaultCompanyValues);
 
-        $this->assertTrue($companyObject instanceof ConfigurationObjectInstance);
+        $this->assertInstanceOf(ConfigurationObjectInstance::class, $companyObject);
         $this->assertFalse($companyObject->getValidationResult()->hasErrors());
 
         /** @var Company $company */

--- a/Tests/Unit/ConfigurationObjectInstanceTest.php
+++ b/Tests/Unit/ConfigurationObjectInstanceTest.php
@@ -5,18 +5,16 @@ use Romm\ConfigurationObject\ConfigurationObjectInstance;
 use Romm\ConfigurationObject\Exceptions\Exception;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithAttributeContainingError;
 use Romm\ConfigurationObject\Tests\Fixture\Validator\WrongValueValidator;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
 use TYPO3\CMS\Extbase\Error\Error;
 use TYPO3\CMS\Extbase\Error\Result;
 
-class ConfigurationObjectInstanceTest extends UnitTestCase
+class ConfigurationObjectInstanceTest extends AbstractUnitTest
 {
-
-    use ConfigurationObjectUnitTestUtility;
 
     public function setUp()
     {
-        $this->injectMockedObjectManagerInCore();
+        parent::setUp();
+
         $this->injectMockedValidatorResolverInCore();
     }
 

--- a/Tests/Unit/ConfigurationObjectUnitTestUtility.php
+++ b/Tests/Unit/ConfigurationObjectUnitTestUtility.php
@@ -6,6 +6,8 @@ use Romm\ConfigurationObject\ConfigurationObjectMapper;
 use Romm\ConfigurationObject\Core\Core;
 use Romm\ConfigurationObject\TypeConverter\ConfigurationObjectConverter;
 use Romm\ConfigurationObject\Validation\ValidatorResolver;
+use TYPO3\CMS\Core\Cache\CacheFactory;
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Extbase\Object\Container\Container;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Extbase\Property\PropertyMappingConfigurationBuilder;
@@ -32,6 +34,7 @@ trait ConfigurationObjectUnitTestUtility
         $this->injectMockedObjectManagerInCore();
         $this->injectMockedValidatorResolverInCore();
         $this->injectMockedConfigurationObjectFactory();
+        $this->injectCacheManagerInCore();
     }
 
     /**
@@ -61,6 +64,22 @@ trait ConfigurationObjectUnitTestUtility
         $objectManagerProperty = $reflectedCore->getProperty('validatorResolver');
         $objectManagerProperty->setAccessible(true);
         $objectManagerProperty->setValue($validatorResolver);
+    }
+
+    /**
+     * Will inject an instance of `CacheManager` in the core, which will be used
+     * later on by objects like the `CacheService`.
+     */
+    public function injectCacheManagerInCore()
+    {
+        $cacheManager = new CacheManager;
+        $cacheFactory = new CacheFactory('foo', $cacheManager);
+        $cacheManager->injectCacheFactory($cacheFactory);
+
+        $reflectedCore = new \ReflectionClass(Core::class);
+        $objectManagerProperty = $reflectedCore->getProperty('cacheManager');
+        $objectManagerProperty->setAccessible(true);
+        $objectManagerProperty->setValue($cacheManager);
     }
 
     /**

--- a/Tests/Unit/ConfigurationObjectUnitTestUtility.php
+++ b/Tests/Unit/ConfigurationObjectUnitTestUtility.php
@@ -25,7 +25,7 @@ trait ConfigurationObjectUnitTestUtility
     /**
      * @var Core|\PHPUnit_Framework_MockObject_MockObject
      */
-    private $configurationObjectCoreMock;
+    protected $configurationObjectCoreMock;
 
     /**
      * Use this function if you need to create a configuration object in your

--- a/Tests/Unit/Service/AbstractServiceTest.php
+++ b/Tests/Unit/Service/AbstractServiceTest.php
@@ -8,9 +8,9 @@ use Romm\ConfigurationObject\Service\DataTransferObject\GetConfigurationObjectDT
 use Romm\ConfigurationObject\Service\ServiceFactory;
 use Romm\ConfigurationObject\Tests\Unit\Service\DataTransferObject\AbstractServiceDTOTest;
 use TYPO3\CMS\Core\Tests\AccessibleObjectInterface;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class AbstractServiceTest extends UnitTestCase
+class AbstractServiceTest extends AbstractUnitTest
 {
 
     /**
@@ -20,6 +20,8 @@ class AbstractServiceTest extends UnitTestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         $this->abstractService = $this->getAccessibleMock(AbstractService::class, ['dummy']);
     }
 

--- a/Tests/Unit/Service/DataTransferObject/AbstractServiceDTOTest.php
+++ b/Tests/Unit/Service/DataTransferObject/AbstractServiceDTOTest.php
@@ -6,9 +6,9 @@ use Romm\ConfigurationObject\Exceptions\ClassNotFoundException;
 use Romm\ConfigurationObject\Exceptions\WrongInheritanceException;
 use Romm\ConfigurationObject\Service\ServiceFactory;
 use Romm\ConfigurationObject\Tests\Fixture\Company\Company;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class AbstractServiceDTOTest extends UnitTestCase
+class AbstractServiceDTOTest extends AbstractUnitTest
 {
 
     const CONFIGURATION_OBJECT_TEST_CLASS = Company::class;
@@ -25,6 +25,8 @@ class AbstractServiceDTOTest extends UnitTestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         /*
          * We instantiate a service factory and a mocked abstract service DTO,
          * which can then be used in the several test cases all along the class.

--- a/Tests/Unit/Service/DataTransferObject/ConfigurationObjectConversionDTOTest.php
+++ b/Tests/Unit/Service/DataTransferObject/ConfigurationObjectConversionDTOTest.php
@@ -3,9 +3,9 @@ namespace Romm\ConfigurationObject\Tests\Unit\Service\DataTransferObject;
 
 use Romm\ConfigurationObject\Service\DataTransferObject\ConfigurationObjectConversionDTO;
 use Romm\ConfigurationObject\Service\ServiceFactory;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class ConfigurationObjectConversionDTOTest extends UnitTestCase
+class ConfigurationObjectConversionDTOTest extends AbstractUnitTest
 {
 
     /**
@@ -15,6 +15,8 @@ class ConfigurationObjectConversionDTOTest extends UnitTestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         $this->configurationObjectConversionDataTransferObject = new ConfigurationObjectConversionDTO(
             AbstractServiceDTOTest::CONFIGURATION_OBJECT_TEST_CLASS,
             ServiceFactory::getInstance()

--- a/Tests/Unit/Service/DataTransferObject/GetConfigurationObjectDTOTest.php
+++ b/Tests/Unit/Service/DataTransferObject/GetConfigurationObjectDTOTest.php
@@ -4,10 +4,10 @@ namespace Romm\ConfigurationObject\Tests\Unit\Service\DataTransferObject;
 use Romm\ConfigurationObject\ConfigurationObjectInstance;
 use Romm\ConfigurationObject\Service\DataTransferObject\GetConfigurationObjectDTO;
 use Romm\ConfigurationObject\Service\ServiceFactory;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 use TYPO3\CMS\Extbase\Error\Result;
 
-class GetConfigurationObjectDTOTest extends UnitTestCase
+class GetConfigurationObjectDTOTest extends AbstractUnitTest
 {
 
     /**
@@ -17,6 +17,8 @@ class GetConfigurationObjectDTOTest extends UnitTestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         $this->getConfigurationObjectDTO = new GetConfigurationObjectDTO(
             AbstractServiceDTOTest::CONFIGURATION_OBJECT_TEST_CLASS,
             ServiceFactory::getInstance()

--- a/Tests/Unit/Service/DataTransferObject/GetTypeConverterDTOTest.php
+++ b/Tests/Unit/Service/DataTransferObject/GetTypeConverterDTOTest.php
@@ -3,10 +3,10 @@ namespace Romm\ConfigurationObject\Tests\Unit\Service\DataTransferObject;
 
 use Romm\ConfigurationObject\Service\DataTransferObject\GetTypeConverterDTO;
 use Romm\ConfigurationObject\Service\ServiceFactory;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 use TYPO3\CMS\Extbase\Property\TypeConverterInterface;
 
-class GetTypeConverterDTOTest extends UnitTestCase
+class GetTypeConverterDTOTest extends AbstractUnitTest
 {
 
     /**
@@ -16,6 +16,8 @@ class GetTypeConverterDTOTest extends UnitTestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         $this->getTypeConverterDataTransferObject = new GetTypeConverterDTO(
             AbstractServiceDTOTest::CONFIGURATION_OBJECT_TEST_CLASS,
             ServiceFactory::getInstance()

--- a/Tests/Unit/Service/Items/Cache/CacheServiceTest.php
+++ b/Tests/Unit/Service/Items/Cache/CacheServiceTest.php
@@ -6,22 +6,14 @@ use Romm\ConfigurationObject\Service\DataTransferObject\GetConfigurationObjectDT
 use Romm\ConfigurationObject\Service\Items\Cache\CacheService;
 use Romm\ConfigurationObject\Service\ServiceFactory;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObject;
-use Romm\ConfigurationObject\Tests\Unit\ConfigurationObjectUnitTestUtility;
 use TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend;
 use TYPO3\CMS\Core\Tests\AccessibleObjectInterface;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 use TYPO3\CMS\Extbase\Error\Error;
 use TYPO3\CMS\Extbase\Error\Result;
 
-class CacheServiceTest extends UnitTestCase
+class CacheServiceTest extends AbstractUnitTest
 {
-
-    use ConfigurationObjectUnitTestUtility;
-
-    public function setUp()
-    {
-        $this->injectCacheManagerInCore();
-    }
 
     /**
      * Will initialize an instance of a cache service, and check that the cache

--- a/Tests/Unit/Service/Items/Cache/CacheServiceTest.php
+++ b/Tests/Unit/Service/Items/Cache/CacheServiceTest.php
@@ -8,8 +8,6 @@ use Romm\ConfigurationObject\Service\ServiceFactory;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObject;
 use Romm\ConfigurationObject\Tests\Unit\ConfigurationObjectUnitTestUtility;
 use TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend;
-use TYPO3\CMS\Core\Cache\CacheFactory;
-use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Tests\AccessibleObjectInterface;
 use TYPO3\CMS\Core\Tests\UnitTestCase;
 use TYPO3\CMS\Extbase\Error\Error;
@@ -19,6 +17,11 @@ class CacheServiceTest extends UnitTestCase
 {
 
     use ConfigurationObjectUnitTestUtility;
+
+    public function setUp()
+    {
+        $this->injectCacheManagerInCore();
+    }
 
     /**
      * Will initialize an instance of a cache service, and check that the cache
@@ -30,9 +33,7 @@ class CacheServiceTest extends UnitTestCase
     {
         /** @var CacheService|AccessibleObjectInterface|\PHPUnit_Framework_MockObject_MockObject $mockedCacheService */
         $mockedCacheService = $this->getAccessibleMock(CacheService::class, ['dummy']);
-        $mockedCacheService->injectObjectManager($this->getObjectManagerMock());
-        /** @var CacheManager $cacheManager */
-        $cacheManager = $mockedCacheService->_call('getCacheManager');
+        $cacheManager = $mockedCacheService->getCacheManager();
 
         $this->assertFalse($cacheManager->hasCache('test'));
 
@@ -70,7 +71,6 @@ class CacheServiceTest extends UnitTestCase
         // Mocking the cache service so we can inject a custom mocked cache instance.
         /** @var CacheService|AccessibleObjectInterface|\PHPUnit_Framework_MockObject_MockObject $mockedCacheService */
         $mockedCacheService = $this->getAccessibleMock(CacheService::class, ['getCacheInstance']);
-        $mockedCacheService->injectObjectManager($this->getObjectManagerMock());
 
         $options = [
             CacheService::OPTION_CACHE_NAME    => $cacheName,
@@ -78,15 +78,9 @@ class CacheServiceTest extends UnitTestCase
         ];
         $mockedCacheService->_set('options', $options);
 
-        // Setting up the cache manager, to initialize the cache service correctly.
-        /** @var CacheManager $cacheManager */
-        $cacheManager = $mockedCacheService->_call('getCacheManager');
-        $cacheFactory = new CacheFactory('test', $cacheManager);
-        $cacheManager->injectCacheFactory($cacheFactory);
-
         $mockedCacheService->initialize();
 
-        $transientMemoryBackendCache = $cacheManager->getCache($cacheName);
+        $transientMemoryBackendCache = $mockedCacheService->getCacheManager()->getCache($cacheName);
 
         $mockedCacheService->method('getCacheInstance')
             ->will($this->returnValue($transientMemoryBackendCache));
@@ -137,7 +131,6 @@ class CacheServiceTest extends UnitTestCase
         // Mocking the cache service so we can inject a custom mocked cache instance.
         /** @var CacheService|AccessibleObjectInterface|\PHPUnit_Framework_MockObject_MockObject $mockedCacheService */
         $mockedCacheService = $this->getAccessibleMock(CacheService::class, ['getCacheInstance']);
-        $mockedCacheService->injectObjectManager($this->getObjectManagerMock());
 
         $options = [
             CacheService::OPTION_CACHE_NAME    => $cacheName,
@@ -145,15 +138,9 @@ class CacheServiceTest extends UnitTestCase
         ];
         $mockedCacheService->_set('options', $options);
 
-        // Setting up the cache manager, to initialize the cache service correctly.
-        /** @var CacheManager $cacheManager */
-        $cacheManager = $mockedCacheService->_call('getCacheManager');
-        $cacheFactory = new CacheFactory('test', $cacheManager);
-        $cacheManager->injectCacheFactory($cacheFactory);
-
         $mockedCacheService->initialize();
 
-        $transientMemoryBackendCache = $cacheManager->getCache($cacheName);
+        $transientMemoryBackendCache = $mockedCacheService->getCacheManager()->getCache($cacheName);
 
         $mockedCacheService->method('getCacheInstance')
             ->will($this->returnValue($transientMemoryBackendCache));
@@ -215,7 +202,6 @@ class CacheServiceTest extends UnitTestCase
         // Mocking the cache service so we can inject a custom mocked cache instance.
         /** @var CacheService|AccessibleObjectInterface|\PHPUnit_Framework_MockObject_MockObject $mockedCacheService */
         $mockedCacheService = $this->getAccessibleMock(CacheService::class, ['getCacheInstance']);
-        $mockedCacheService->injectObjectManager($this->getObjectManagerMock());
 
         $options = [
             CacheService::OPTION_CACHE_NAME    => $cacheName,
@@ -223,15 +209,9 @@ class CacheServiceTest extends UnitTestCase
         ];
         $mockedCacheService->_set('options', $options);
 
-        // Setting up the cache manager, to initialize the cache service correctly.
-        /** @var CacheManager $cacheManager */
-        $cacheManager = $mockedCacheService->_call('getCacheManager');
-        $cacheFactory = new CacheFactory('test', $cacheManager);
-        $cacheManager->injectCacheFactory($cacheFactory);
-
         $mockedCacheService->initialize();
 
-        $transientMemoryBackendCache = $cacheManager->getCache($cacheName);
+        $transientMemoryBackendCache = $mockedCacheService->getCacheManager()->getCache($cacheName);
 
         $mockedCacheService->method('getCacheInstance')
             ->will($this->returnValue($transientMemoryBackendCache));

--- a/Tests/Unit/Service/Items/ConfigurationArray/StoreConfigurationArrayServiceTest.php
+++ b/Tests/Unit/Service/Items/ConfigurationArray/StoreConfigurationArrayServiceTest.php
@@ -7,9 +7,9 @@ use Romm\ConfigurationObject\Service\Items\StoreConfigurationArray\StoreConfigur
 use Romm\ConfigurationObject\Service\ServiceFactory;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObject;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithConfigurationArrayTrait;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class StoreConfigurationArrayServiceTest extends UnitTestCase
+class StoreConfigurationArrayServiceTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Service/Items/DataPreProcessor/DataPreProcessorServiceTest.php
+++ b/Tests/Unit/Service/Items/DataPreProcessor/DataPreProcessorServiceTest.php
@@ -3,9 +3,9 @@ namespace Romm\ConfigurationObject\Tests\Unit\Service\Items\DataPreProcessor;
 
 use Romm\ConfigurationObject\Service\Items\DataPreProcessor\DataPreProcessorService;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithDataPreProcessor;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class DataPreProcessorServiceTest extends UnitTestCase
+class DataPreProcessorServiceTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Service/Items/DataPreProcessor/DataPreProcessorTest.php
+++ b/Tests/Unit/Service/Items/DataPreProcessor/DataPreProcessorTest.php
@@ -2,11 +2,11 @@
 namespace Romm\ConfigurationObject\Tests\Unit\Service\Items\DataPreProcessor;
 
 use Romm\ConfigurationObject\Service\Items\DataPreProcessor\DataPreProcessor;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 use TYPO3\CMS\Extbase\Error\Error;
 use TYPO3\CMS\Extbase\Error\Result;
 
-class DataPreProcessorTest extends UnitTestCase
+class DataPreProcessorTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Service/Items/MixedTypes/MixedTypesResolverTest.php
+++ b/Tests/Unit/Service/Items/MixedTypes/MixedTypesResolverTest.php
@@ -2,11 +2,11 @@
 namespace Romm\ConfigurationObject\Tests\Unit\Service\Items\MixedTypes;
 
 use Romm\ConfigurationObject\Service\Items\MixedTypes\MixedTypesResolver;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 use TYPO3\CMS\Extbase\Error\Error;
 use TYPO3\CMS\Extbase\Error\Result;
 
-class MixedTypesResolverTest extends UnitTestCase
+class MixedTypesResolverTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Service/Items/MixedTypes/MixedTypesServiceTest.php
+++ b/Tests/Unit/Service/Items/MixedTypes/MixedTypesServiceTest.php
@@ -3,9 +3,9 @@ namespace Romm\ConfigurationObject\Tests\Unit\Service\Items\DataPreProcessor;
 
 use Romm\ConfigurationObject\Service\Items\MixedTypes\MixedTypesService;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithMixedTypes;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class MixedTypesServiceTest extends UnitTestCase
+class MixedTypesServiceTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Service/Items/Parents/ParentsServiceTest.php
+++ b/Tests/Unit/Service/Items/Parents/ParentsServiceTest.php
@@ -7,10 +7,10 @@ use Romm\ConfigurationObject\Service\DataTransferObject\GetConfigurationObjectDT
 use Romm\ConfigurationObject\Service\Items\Parents\ParentsService;
 use Romm\ConfigurationObject\Service\ServiceFactory;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithParentsTrait;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 use TYPO3\CMS\Extbase\Error\Result;
 
-class ParentsServiceTest extends UnitTestCase
+class ParentsServiceTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Service/Items/Parents/ParentsTraitTest.php
+++ b/Tests/Unit/Service/Items/Parents/ParentsTraitTest.php
@@ -3,9 +3,9 @@ namespace Romm\ConfigurationObject\Tests\Unit\Service\Items\Parents;
 
 use Romm\ConfigurationObject\Exceptions\EntryNotFoundException;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithParentsTrait;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class ParentsTraitTest extends UnitTestCase
+class ParentsTraitTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Service/Items/Parents/ParentsUtilityTest.php
+++ b/Tests/Unit/Service/Items/Parents/ParentsUtilityTest.php
@@ -3,9 +3,9 @@ namespace Romm\ConfigurationObject\Tests\Unit\Service\Items\Parents;
 
 use Romm\ConfigurationObject\Service\Items\Parents\ParentsUtility;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithParentsTrait;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class ParentsUtilityTest extends UnitTestCase
+class ParentsUtilityTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Service/Items/Persistence/PersistenceServiceTest.php
+++ b/Tests/Unit/Service/Items/Persistence/PersistenceServiceTest.php
@@ -8,11 +8,11 @@ use Romm\ConfigurationObject\Service\Items\Persistence\PersistenceService;
 use Romm\ConfigurationObject\Service\ServiceFactory;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithPersistenceAttribute;
 use TYPO3\CMS\Beuser\Domain\Model\BackendUser;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 use TYPO3\CMS\Extbase\Error\Result;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
-class PersistenceServiceTest extends UnitTestCase
+class PersistenceServiceTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Service/ServiceFactoryTest.php
+++ b/Tests/Unit/Service/ServiceFactoryTest.php
@@ -27,7 +27,7 @@ class ServiceFactoryTest extends AbstractUnitTest
     public function classGetterWorks()
     {
         $serviceFactory = ServiceFactory::getInstance();
-        $this->assertEquals(get_class($serviceFactory), ServiceFactory::class);
+        $this->assertInstanceOf(ServiceFactory::class, $serviceFactory);
 
         unset($serviceFactory);
     }

--- a/Tests/Unit/Service/ServiceFactoryTest.php
+++ b/Tests/Unit/Service/ServiceFactoryTest.php
@@ -12,19 +12,11 @@ use Romm\ConfigurationObject\Service\Items\Parents\ParentsService;
 use Romm\ConfigurationObject\Service\ServiceFactory;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObject;
 use Romm\ConfigurationObject\Tests\Unit\Service\Fixture\DummyService;
-use Romm\ConfigurationObject\Tests\Unit\ConfigurationObjectUnitTestUtility;
 use TYPO3\CMS\Core\Tests\AccessibleObjectInterface;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class ServiceFactoryTest extends UnitTestCase
+class ServiceFactoryTest extends AbstractUnitTest
 {
-
-    use ConfigurationObjectUnitTestUtility;
-
-    protected function setUp()
-    {
-        $this->injectMockedObjectManagerInCore();
-    }
 
     /**
      * Checks if the static getter of the service factory class returns a

--- a/Tests/Unit/Traits/ConfigurationObject/ArrayConversionTraitTest.php
+++ b/Tests/Unit/Traits/ConfigurationObject/ArrayConversionTraitTest.php
@@ -3,10 +3,10 @@ namespace Romm\ConfigurationObject\Tests\Unit\Traits\ConfigurationObject;
 
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObject;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyObjectWithFooAttribute;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
-class ArrayConversionTraitTest extends UnitTestCase
+class ArrayConversionTraitTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Traits/ConfigurationObject/DefaultConfigurationObjectTraitTest.php
+++ b/Tests/Unit/Traits/ConfigurationObject/DefaultConfigurationObjectTraitTest.php
@@ -3,9 +3,9 @@ namespace Romm\ConfigurationObject\Tests\Unit\Traits\ConfigurationObject;
 
 use Romm\ConfigurationObject\Service\ServiceFactory;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObject;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class DefaultConfigurationObjectTraitTest extends UnitTestCase
+class DefaultConfigurationObjectTraitTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Traits/ConfigurationObject/DefaultConfigurationObjectTraitTest.php
+++ b/Tests/Unit/Traits/ConfigurationObject/DefaultConfigurationObjectTraitTest.php
@@ -19,10 +19,7 @@ class DefaultConfigurationObjectTraitTest extends AbstractUnitTest
         $serviceFactory = DummyConfigurationObject::getConfigurationObjectServices();
 
         // Checking the returned instance is a `ServiceFactory` instance.
-        $this->assertEquals(ServiceFactory::class, get_class($serviceFactory));
-
-        // The default service factory must be a basic instance.
-        $this->assertEquals(serialize(ServiceFactory::getInstance()), serialize($serviceFactory));
+        $this->assertInstanceOf(ServiceFactory::class, $serviceFactory);
 
         unset($serviceFactory);
     }

--- a/Tests/Unit/Traits/ConfigurationObject/MagicMethodsTraitTest.php
+++ b/Tests/Unit/Traits/ConfigurationObject/MagicMethodsTraitTest.php
@@ -3,9 +3,9 @@ namespace Romm\ConfigurationObject\Tests\Unit\Traits\ConfigurationObject;
 
 use Romm\ConfigurationObject\Exceptions\MethodNotFoundException;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithUpperCaseProperty;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class MagicMethodsTraitTest extends UnitTestCase
+class MagicMethodsTraitTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Traits/ConfigurationObject/StoreArrayIndexTraitTest.php
+++ b/Tests/Unit/Traits/ConfigurationObject/StoreArrayIndexTraitTest.php
@@ -2,9 +2,9 @@
 namespace Romm\ConfigurationObject\Tests\Unit\Traits\ConfigurationObject;
 
 use Romm\ConfigurationObject\Traits\ConfigurationObject\StoreArrayIndexTrait;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class StoreArrayIndexTraitTest extends UnitTestCase
+class StoreArrayIndexTraitTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Traits/InternalVariablesTraitTest.php
+++ b/Tests/Unit/Traits/InternalVariablesTraitTest.php
@@ -2,9 +2,9 @@
 namespace Romm\ConfigurationObject\Tests\Unit\Traits;
 
 use Romm\ConfigurationObject\Traits\InternalVariablesTrait;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class InternalVariablesTraitTest extends UnitTestCase
+class InternalVariablesTraitTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/TypeConverter/ArrayConverterTest.php
+++ b/Tests/Unit/TypeConverter/ArrayConverterTest.php
@@ -3,9 +3,9 @@ namespace Romm\ConfigurationObject\Tests\Unit\TypeConverter;
 
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithStoreArrayIndexTrait;
 use Romm\ConfigurationObject\TypeConverter\ArrayConverter;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
-class ArrayConverterTest extends UnitTestCase
+class ArrayConverterTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Validation/Validator/AbstractValidatorTest.php
+++ b/Tests/Unit/Validation/Validator/AbstractValidatorTest.php
@@ -1,10 +1,10 @@
 <?php
 namespace Romm\ConfigurationObject\Tests\Unit\Validation\Validator;
 
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 use TYPO3\CMS\Extbase\Validation\Validator\ValidatorInterface;
 
-abstract class AbstractValidatorTest extends UnitTestCase
+abstract class AbstractValidatorTest extends AbstractUnitTest
 {
 
     /**

--- a/Tests/Unit/Validation/ValidatorResolverTest.php
+++ b/Tests/Unit/Validation/ValidatorResolverTest.php
@@ -3,24 +3,16 @@ namespace Romm\ConfigurationObject\Tests\Unit\Validation;
 
 use Romm\ConfigurationObject\Core\Core;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithMixedTypes;
-use Romm\ConfigurationObject\Tests\Unit\ConfigurationObjectUnitTestUtility;
 use Romm\ConfigurationObject\Validation\Validator\Internal\MixedTypeCollectionValidator;
 use Romm\ConfigurationObject\Validation\Validator\Internal\MixedTypeObjectValidator;
 use Romm\ConfigurationObject\Validation\ValidatorResolver;
-use TYPO3\CMS\Core\Tests\UnitTestCase;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 use TYPO3\CMS\Extbase\Validation\ValidatorResolver as ExtbaseValidatorResolver;
 use TYPO3\CMS\Extbase\Validation\Validator\BooleanValidator;
 use TYPO3\CMS\Extbase\Validation\Validator\CollectionValidator;
 
-class ValidatorResolverTest extends UnitTestCase
+class ValidatorResolverTest extends AbstractUnitTest
 {
-
-    use ConfigurationObjectUnitTestUtility;
-
-    public function setUp()
-    {
-        $this->injectMockedObjectManagerInCore();
-    }
 
     /**
      * Will check if the resolver checks the type of the validator before its
@@ -32,15 +24,15 @@ class ValidatorResolverTest extends UnitTestCase
      */
     public function createValidatorChecksCollectionType()
     {
-        $reflectionService = Core::getReflectionService();
-        $reflectionService->injectObjectManager(Core::getObjectManager());
+        $reflectionService = Core::get()->getReflectionService();
+        $reflectionService->injectObjectManager(Core::get()->getObjectManager());
 
         $validatorResolver = new ValidatorResolver();
-        $validatorResolver->injectObjectManager(Core::getObjectManager());
+        $validatorResolver->injectObjectManager(Core::get()->getObjectManager());
         $validatorResolver->injectReflectionService($reflectionService);
 
         $extbaseValidatorResolver = new ExtbaseValidatorResolver();
-        $extbaseValidatorResolver->injectObjectManager(Core::getObjectManager());
+        $extbaseValidatorResolver->injectObjectManager(Core::get()->getObjectManager());
         $extbaseValidatorResolver->injectReflectionService($reflectionService);
 
         $validator = $validatorResolver->createValidator(CollectionValidator::class);
@@ -70,12 +62,12 @@ class ValidatorResolverTest extends UnitTestCase
      */
     public function getBaseValidatorConjunctionCheckMixedTypes()
     {
-        $reflectionService = Core::getReflectionService();
-        $reflectionService->injectObjectManager(Core::getObjectManager());
+        $reflectionService = Core::get()->getReflectionService();
+        $reflectionService->injectObjectManager(Core::get()->getObjectManager());
 
         /** @var ValidatorResolver|\PHPUnit_Framework_MockObject_MockObject $validatorResolver */
         $validatorResolver = $this->getMock(ValidatorResolver::class, ['getBaseValidatorConjunction']);
-        $validatorResolver->injectObjectManager(Core::getObjectManager());
+        $validatorResolver->injectObjectManager(Core::get()->getObjectManager());
         $validatorResolver->injectReflectionService($reflectionService);
 
         $validatorResolver->expects($this->never())
@@ -98,7 +90,7 @@ class ValidatorResolverTest extends UnitTestCase
          */
         /** @var ValidatorResolver|\PHPUnit_Framework_MockObject_MockObject $validatorResolver */
         $validatorResolver = $this->getMock(ValidatorResolver::class, ['getBaseValidatorConjunction']);
-        $validatorResolver->injectObjectManager(Core::getObjectManager());
+        $validatorResolver->injectObjectManager(Core::get()->getObjectManager());
         $validatorResolver->injectReflectionService($reflectionService);
 
         $validatorResolver->expects($this->once())

--- a/Tests/Unit/Validation/ValidatorResolverTest.php
+++ b/Tests/Unit/Validation/ValidatorResolverTest.php
@@ -37,7 +37,7 @@ class ValidatorResolverTest extends AbstractUnitTest
 
         $validator = $validatorResolver->createValidator(CollectionValidator::class);
 
-        $this->assertTrue($validator instanceof MixedTypeCollectionValidator);
+        $this->assertInstanceOf(MixedTypeCollectionValidator::class, $validator);
 
         /*
          * If we try to create something different than the validator
@@ -47,8 +47,8 @@ class ValidatorResolverTest extends AbstractUnitTest
         $validator = $validatorResolver->createValidator(BooleanValidator::class);
         $validatorWithExtbase = $extbaseValidatorResolver->createValidator(BooleanValidator::class);
 
-        $this->assertTrue($validator instanceof BooleanValidator);
-        $this->assertTrue($validatorWithExtbase instanceof BooleanValidator);
+        $this->assertInstanceOf(BooleanValidator::class, $validator);
+        $this->assertInstanceOf(BooleanValidator::class, $validatorWithExtbase);
 
         unset($validatorResolver);
         unset($extbaseValidatorResolver);


### PR DESCRIPTION
Currently, using a configuration object which attached the cache service inside a unit test would cause a fatal error.

This PR fixes this issue.

Some refactoring had to be done in order to mock correctly the classes.
