### PR TITLE
[FEATURE] Introduce `@disableMagicMethods` tag support

### DIFF
--- a/Documentation/04-Administration/Utilities/Index.rst
+++ b/Documentation/04-Administration/Utilities/Index.rst
@@ -173,6 +173,39 @@ Because objects can have a lot of properties, you may want not to be forced to w
     $bar = $myObject->getBar(); // Will work as well.
     $bar = $myObject->setBar('bar'); // You got it? :)
 
+.. note::
+
+    If for some reason you want to disable the magic methods for a given property, you need to tag it with ``@disableMagicMethods``.
+
+    **Example:**
+
+    .. code-block:: php
+        :linenos:
+        :emphasize-lines: 19
+
+        use Romm\ConfObj\ConfigurationObjectInterface;
+        use Romm\ConfObj\Traits\ConfigurationObject\DefaultConfigurationObjectTrait;
+        use Romm\ConfObj\Traits\ConfigurationObject\MagicMethodsTrait;
+
+        class MyObject implements ConfigurationObjectInterface
+        {
+            use DefaultConfigurationObjectTrait;
+            use MagicMethodsTrait;
+
+            /**
+             * @var string
+             */
+            protected $foo;
+
+            /**
+             * This property will not be accessible by magic setter/getter.
+             *
+             * @var string
+             * @disableMagicMethods
+             */
+            protected $bar;
+        }
+
 .. hint::
 
     The usage of this trait will not provide auto-completion in IDEs like PhpStorm. But you can still use the class annotation ``@method`` (see `phpDoc official documentation <https://phpdoc.org/docs/latest/references/phpdoc/tags/method.html>`_) to simulate it.

--- a/Tests/Fixture/Model/DummyConfigurationObject.php
+++ b/Tests/Fixture/Model/DummyConfigurationObject.php
@@ -31,6 +31,12 @@ class DummyConfigurationObject implements ConfigurationObjectInterface
     protected $bar;
 
     /**
+     * @var array
+     * @disableMagicMethods
+     */
+    protected $baz;
+
+    /**
      * @var \Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObject
      */
     protected $subObject;

--- a/Tests/Unit/Traits/ConfigurationObject/MagicMethodsTraitTest.php
+++ b/Tests/Unit/Traits/ConfigurationObject/MagicMethodsTraitTest.php
@@ -29,7 +29,6 @@ class MagicMethodsTraitTest extends AbstractUnitTest
         $dummyConfigurationObject->setBar($bar);
         $dummyConfigurationObject->setUpperCaseProperty($foo);
 
-
         $this->assertEquals($foo, $dummyConfigurationObject->getFoo());
         $this->assertEquals($bar, $dummyConfigurationObject->getBar());
         $this->assertEquals($foo, $dummyConfigurationObject->getUpperCaseProperty());
@@ -65,6 +64,5 @@ class MagicMethodsTraitTest extends AbstractUnitTest
         $this->assertEquals(null, call_user_func([$dummyConfigurationObject, 'setBaz']));
 
         unset($dummyConfigurationObject);
-
     }
 }

--- a/Tests/Unit/Traits/ConfigurationObject/MagicMethodsTraitTest.php
+++ b/Tests/Unit/Traits/ConfigurationObject/MagicMethodsTraitTest.php
@@ -2,6 +2,7 @@
 namespace Romm\ConfigurationObject\Tests\Unit\Traits\ConfigurationObject;
 
 use Romm\ConfigurationObject\Exceptions\MethodNotFoundException;
+use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObject;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithUpperCaseProperty;
 use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 
@@ -28,14 +29,42 @@ class MagicMethodsTraitTest extends AbstractUnitTest
         $dummyConfigurationObject->setBar($bar);
         $dummyConfigurationObject->setUpperCaseProperty($foo);
 
+
         $this->assertEquals($foo, $dummyConfigurationObject->getFoo());
         $this->assertEquals($bar, $dummyConfigurationObject->getBar());
         $this->assertEquals($foo, $dummyConfigurationObject->getUpperCaseProperty());
 
-        // Trying to call a not existing getter should throw an exception.
+        unset($dummyConfigurationObject);
+    }
+
+    /**
+     * Trying to call a not existing getter should throw an exception.
+     *
+     * @test
+     */
+    public function unknownMethodThrowsException()
+    {
+        $dummyConfigurationObject = new DummyConfigurationObject();
+
         $this->setExpectedException(MethodNotFoundException::class);
         $this->assertEquals(null, call_user_func([$dummyConfigurationObject, 'getNotExistingProperty']));
 
         unset($dummyConfigurationObject);
+    }
+
+    /**
+     * A property tagged with `@disableMagicMethods` should not be callable.
+     *
+     * @test
+     */
+    public function disabledMagicMethodIsNotCalled()
+    {
+        $dummyConfigurationObject = new DummyConfigurationObject();
+
+        $this->setExpectedException(MethodNotFoundException::class);
+        $this->assertEquals(null, call_user_func([$dummyConfigurationObject, 'setBaz']));
+
+        unset($dummyConfigurationObject);
+
     }
 }


### PR DESCRIPTION
This new `@disableMagicMethods` tag can be used on a class property to cancel the magic methods provided by [MagicMethodsTrait](https://github.com/romm/configuration_object/blob/1.4.0/Classes/Traits/ConfigurationObject/MagicMethodsTrait.php#L28).