### PR TITLE
[BUGFIX] Fix incorrect cache handling

### DIFF
--- a/Classes/Core/Core.php
+++ b/Classes/Core/Core.php
@@ -13,6 +13,7 @@
 
 namespace Romm\ConfigurationObject\Core;
 
+use Romm\ConfigurationObject\Core\Service\CacheService;
 use Romm\ConfigurationObject\Exceptions\MethodNotFoundException;
 use Romm\ConfigurationObject\Service\Items\Parents\ParentsUtility;
 use Romm\ConfigurationObject\Service\ServiceFactory;
@@ -32,7 +33,6 @@ use TYPO3\CMS\Extbase\Reflection\ReflectionService;
  */
 class Core implements SingletonInterface
 {
-
     /**
      * @var Core
      */
@@ -62,6 +62,11 @@ class Core implements SingletonInterface
      * @var ParentsUtility
      */
     protected $parentsUtility;
+
+    /**
+     * @var CacheService
+     */
+    protected $cacheService;
 
     /**
      * @var array
@@ -173,7 +178,10 @@ class Core implements SingletonInterface
      */
     public function getServiceFactoryInstance()
     {
-        return GeneralUtility::makeInstance(ServiceFactory::class);
+        /** @var ServiceFactory $serviceFactory */
+        $serviceFactory = GeneralUtility::makeInstance(ServiceFactory::class);
+
+        return $serviceFactory;
     }
 
     /**
@@ -254,5 +262,21 @@ class Core implements SingletonInterface
     public function injectParentsUtility(ParentsUtility $parentsUtility)
     {
         $this->parentsUtility = $parentsUtility;
+    }
+
+    /**
+     * @return CacheService
+     */
+    public function getCacheService()
+    {
+        return $this->cacheService;
+    }
+
+    /**
+     * @param CacheService $cacheService
+     */
+    public function injectCacheService(CacheService $cacheService)
+    {
+        $this->cacheService = $cacheService;
     }
 }

--- a/Classes/Core/Service/CacheService.php
+++ b/Classes/Core/Service/CacheService.php
@@ -1,0 +1,127 @@
+<?php
+/*
+ * 2017 Romain CANON <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 Configuration Object project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Romm\ConfigurationObject\Core\Service;
+
+use TYPO3\CMS\Core\Cache\Backend\FileBackend;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class CacheService implements SingletonInterface
+{
+    const CACHE_IDENTIFIER = 'cache_configuration_object';
+    const CACHE_TAG_DYNAMIC_CACHE = 'dynamic-cache';
+
+    /**
+     * Options for the internal cache.
+     *
+     * @var array
+     */
+    protected $cacheOptions = [
+        'backend'  => FileBackend::class,
+        'frontend' => VariableFrontend::class,
+        'groups'   => ['all', 'system']
+    ];
+
+    /**
+     * Function called from `ext_localconf` file which will register the
+     * internal cache earlier.
+     *
+     * @internal
+     */
+    public function registerInternalCache()
+    {
+        $this->getCacheManager()
+            ->setCacheConfigurations([self::CACHE_IDENTIFIER => $this->cacheOptions]);
+    }
+
+    /**
+     * This function will take care of initializing all caches that were defined
+     * previously  by the `CacheService` which allows dynamic caches to be used
+     * for every configuration object type.
+     *
+     * @see \Romm\ConfigurationObject\Service\Items\Cache\CacheService::initialize()
+     * @internal
+     */
+    public function registerDynamicCaches()
+    {
+        $dynamicCaches = $this->getCache()->getByTag(self::CACHE_TAG_DYNAMIC_CACHE);
+
+        foreach ($dynamicCaches as $cacheData) {
+            $identifier = $cacheData['identifier'];
+            $options = $cacheData['options'];
+
+            $this->registerCacheInternal($identifier, $options);
+        }
+    }
+
+    /**
+     * Registers a new dynamic cache: the cache will be added to the cache
+     * manager after this function is executed. Its configuration will also be
+     * remembered so the cache will be registered properly during the cache
+     * framework initialization in further requests.
+     *
+     * @param string $identifier
+     * @param array  $options
+     */
+    public function registerDynamicCache($identifier, array $options)
+    {
+        if (false === $this->getCache()->has($identifier)) {
+            $this->getCache()->set(
+                $identifier,
+                [
+                    'identifier' => $identifier,
+                    'options'    => $options
+                ],
+                [self::CACHE_TAG_DYNAMIC_CACHE]
+            );
+        }
+
+        $this->registerCacheInternal($identifier, $options);
+    }
+
+    /**
+     * @param string $identifier
+     * @param array  $options
+     */
+    protected function registerCacheInternal($identifier, array $options)
+    {
+        $cacheManager = $this->getCacheManager();
+
+        if (false === $cacheManager->hasCache($identifier)) {
+            $cacheManager->setCacheConfigurations([$identifier => $options]);
+        }
+    }
+
+    /**
+     * @return FrontendInterface
+     */
+    protected function getCache()
+    {
+        return $this->getCacheManager()->getCache(self::CACHE_IDENTIFIER);
+    }
+
+    /**
+     * @return CacheManager
+     */
+    protected function getCacheManager()
+    {
+        /** @var CacheManager $cacheManager */
+        $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
+
+        return $cacheManager;
+    }
+}

--- a/Classes/Service/Items/Cache/CacheService.php
+++ b/Classes/Service/Items/Cache/CacheService.php
@@ -52,7 +52,7 @@ class CacheService extends AbstractService implements ConfigurationObjectBeforeS
     /**
      * Default identifier of the cache instance.
      */
-    const DEFAULT_CACHE_IDENTIFIER = 'cache_configuration_object';
+    const DEFAULT_CACHE_IDENTIFIER = 'cache_configuration_object_default';
 
     /**
      * Default backend cache class name.
@@ -119,18 +119,17 @@ class CacheService extends AbstractService implements ConfigurationObjectBeforeS
     public function initialize()
     {
         $this->cacheIdentifier = $this->options[self::OPTION_CACHE_NAME];
+        $options = [
+            'backend'  => $this->options[self::OPTION_CACHE_BACKEND],
+            'frontend' => VariableFrontend::class,
+            'groups'   => $this->options[self::OPTION_CACHE_GROUPS],
+            'options'  => $this->options[self::OPTION_CACHE_OPTIONS]
+        ];
 
         // Adds the cache to the list of TYPO3 caches.
-        $this->getCacheManager()->setCacheConfigurations(
-            [
-                $this->cacheIdentifier => [
-                    'backend'  => $this->options[self::OPTION_CACHE_BACKEND],
-                    'frontend' => VariableFrontend::class,
-                    'groups'   => $this->options[self::OPTION_CACHE_GROUPS],
-                    'options'  => $this->options[self::OPTION_CACHE_OPTIONS]
-                ]
-            ]
-        );
+        Core::get()
+            ->getCacheService()
+            ->registerDynamicCache($this->cacheIdentifier, $options);
     }
 
     /**

--- a/Tests/Unit/ConfigurationObjectUnitTestUtility.php
+++ b/Tests/Unit/ConfigurationObjectUnitTestUtility.php
@@ -4,6 +4,7 @@ namespace Romm\ConfigurationObject\Tests\Unit;
 use Romm\ConfigurationObject\ConfigurationObjectFactory;
 use Romm\ConfigurationObject\ConfigurationObjectMapper;
 use Romm\ConfigurationObject\Core\Core;
+use Romm\ConfigurationObject\Core\Service\CacheService as InternalCacheService;
 use Romm\ConfigurationObject\Service\Items\Cache\CacheService;
 use Romm\ConfigurationObject\Service\Items\Parents\ParentsUtility;
 use Romm\ConfigurationObject\Service\ServiceFactory;
@@ -12,6 +13,7 @@ use Romm\ConfigurationObject\Validation\ValidatorResolver;
 use TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend;
 use TYPO3\CMS\Core\Cache\CacheFactory;
 use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Extbase\Object\Container\Container;
@@ -79,6 +81,7 @@ trait ConfigurationObjectUnitTestUtility
         $this->configurationObjectCoreMock->injectReflectionService(new ReflectionService);
         $this->configurationObjectCoreMock->injectValidatorResolver(new ValidatorResolver);
         $this->configurationObjectCoreMock->injectParentsUtility(new ParentsUtility);
+        $this->configurationObjectCoreMock->injectCacheService(new InternalCacheService);
 
         $this->configurationObjectCoreMock->method('getServiceFactoryInstance')
             ->will(
@@ -115,6 +118,13 @@ trait ConfigurationObjectUnitTestUtility
             $cacheFactory = new CacheFactory('foo', $cacheManager);
             $cacheManager->injectCacheFactory($cacheFactory);
         }
+
+        $cacheManager->setCacheConfigurations([
+            InternalCacheService::CACHE_IDENTIFIER => [
+                'backend'  => TransientMemoryBackend::class,
+                'frontend' => VariableFrontend::class
+            ]
+        ]);
 
         $this->configurationObjectCoreMock->injectCacheManager($cacheManager);
 

--- a/Tests/Unit/Core/Service/CacheServiceTest.php
+++ b/Tests/Unit/Core/Service/CacheServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+namespace Romm\ConfigurationObject\Tests\Unit\Core\Service\Cache;
+
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Romm\ConfigurationObject\Core\Service\CacheService;
+use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
+
+class CacheServiceTest extends AbstractUnitTest
+{
+    /**
+     * Checks that the internal cache used by the API is properly registered
+     * during TYPO3 initialization.
+     *
+     * @test
+     */
+    public function internalCacheIsRegisteredProperly()
+    {
+        $cacheManager = new CacheManager;
+
+        /** @var CacheService|\PHPUnit_Framework_MockObject_MockObject $cacheServiceMock */
+        $cacheServiceMock = $this->getMockBuilder(CacheService::class)
+            ->setMethods(['getCacheManager'])
+            ->getMock();
+
+        $cacheServiceMock->method('getCacheManager')
+            ->willReturn($cacheManager);
+
+        $this->assertFalse($cacheManager->hasCache(CacheService::CACHE_IDENTIFIER));
+        $cacheServiceMock->registerInternalCache();
+        $this->assertTrue($cacheManager->hasCache(CacheService::CACHE_IDENTIFIER));
+    }
+
+    /**
+     * Checks that a cache can be registered dynamically, and only once per
+     * request.
+     *
+     * @test
+     */
+    public function registerDynamicCacheWorksProperly()
+    {
+        $cacheIdentifier = 'foo';
+        $cacheOptions = ['bar' => 'baz'];
+
+        /** @var CacheService|\PHPUnit_Framework_MockObject_MockObject $cacheServiceMock */
+        $cacheServiceMock = $this->getMockBuilder(CacheService::class)
+            ->setMethods(['getCache', 'getCacheManager'])
+            ->getMock();
+
+        /** @var VariableFrontend|ObjectProphecy $cacheProphecy */
+        $cacheProphecy = $this->prophesize(VariableFrontend::class);
+
+        $cacheProphecy->has($cacheIdentifier)
+            ->shouldBeCalledTimes(2)
+            ->will(function () use ($cacheProphecy, $cacheIdentifier, $cacheOptions) {
+                $cacheProphecy->set($cacheIdentifier, Argument::type('array'), [CacheService::CACHE_TAG_DYNAMIC_CACHE])
+                    ->shouldBeCalledTimes(1);
+
+                $cacheProphecy->has($cacheIdentifier)
+                    ->willReturn(true);
+
+                return false;
+            });
+
+        $cacheProphecy->getByTag(CacheService::CACHE_TAG_DYNAMIC_CACHE)
+            ->shouldBeCalledTimes(1)
+            ->willReturn([
+                'foo' => [
+                    'identifier' => 'foo',
+                    'options'    => []
+                ]
+            ]);
+
+        $cacheServiceMock->method('getCache')
+            ->willReturn($cacheProphecy->reveal());
+
+        /** @var CacheManager|ObjectProphecy $cacheManagerProphecy */
+        $cacheManagerProphecy = $this->prophesize(CacheManager::class);
+
+        $cacheManagerProphecy->hasCache($cacheIdentifier)
+            ->shouldBeCalledTimes(3)
+            ->will(function () use ($cacheManagerProphecy, $cacheIdentifier) {
+                $cacheManagerProphecy->hasCache($cacheIdentifier)
+                    ->willReturn(true);
+
+                $cacheManagerProphecy->setCacheConfigurations(Argument::type('array'))
+                    ->shouldBeCalledTimes(1);
+
+                return false;
+            });
+
+        $cacheServiceMock->method('getCacheManager')
+            ->willReturn($cacheManagerProphecy->reveal());
+
+        $cacheServiceMock->registerDynamicCache($cacheIdentifier, $cacheOptions);
+        $cacheServiceMock->registerDynamicCache($cacheIdentifier, $cacheOptions);
+        $cacheServiceMock->registerDynamicCaches();
+    }
+}

--- a/Tests/Unit/Service/Items/Cache/CacheServiceTest.php
+++ b/Tests/Unit/Service/Items/Cache/CacheServiceTest.php
@@ -2,6 +2,7 @@
 namespace Romm\ConfigurationObject\Tests\Unit\Service\Items\Cache;
 
 use Romm\ConfigurationObject\ConfigurationObjectInstance;
+use Romm\ConfigurationObject\Core\Service\CacheService as InternalCacheService;
 use Romm\ConfigurationObject\Service\DataTransferObject\GetConfigurationObjectDTO;
 use Romm\ConfigurationObject\Service\Items\Cache\CacheService;
 use Romm\ConfigurationObject\Service\ServiceFactory;
@@ -14,6 +15,18 @@ use TYPO3\CMS\Extbase\Error\Result;
 
 class CacheServiceTest extends AbstractUnitTest
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        /** @var InternalCacheService|\PHPUnit_Framework_MockObject_MockObject $cacheServiceMock */
+        $cacheServiceMock = $this->getMockBuilder(InternalCacheService::class)
+            ->setMethods(['getCacheManager'])
+            ->getMock();
+        $cacheServiceMock->method('getCacheManager')
+            ->willReturn($this->configurationObjectCoreMock->getCacheManager());
+        $this->configurationObjectCoreMock->injectCacheService($cacheServiceMock);
+    }
 
     /**
      * Will initialize an instance of a cache service, and check that the cache

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": ">=5.5",
-    "typo3/cms": "^6.2 || ^7.6 || ^8.5"
+    "typo3/cms": "^6.2 || ^7.6 || ^8.6.1"
   },
   "require-dev": {
     "mikey179/vfsStream": "1.4.*@dev",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
 
     'constraints' => [
         'depends'   => [
-            'typo3' => '6.2.0-8.5.99',
+            'typo3' => '6.2.0-8.6.99',
             'php'   => '5.5.0-7.99.99'
         ],
         'conflicts' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,13 @@
+<?php
+if (!defined('TYPO3_MODE')) {
+    throw new \Exception('Access denied.');
+}
+
+call_user_func(
+    function () {
+        /** @var \Romm\ConfigurationObject\Core\Service\CacheService $cacheService */
+        $cacheService = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Romm\ConfigurationObject\Core\Service\CacheService::class);
+        $cacheService->registerInternalCache();
+        $cacheService->registerDynamicCaches();
+    }
+);


### PR DESCRIPTION
This commit refactors a major part of how "dynamic" caches were handled by Configuration Object API. In the provided cache service that can be attached to a configuration object, it is possible to declare the options for this cache; it means the cache is registered long after TYPO3 initialization, resulting in issues like caches entries not being deleted on caches flush.

A new internal cache service has been introduced, which will handle these "dynamic" caches: when one of these caches is used, its configuration is saved in the internal cache: in further request, the cache will be properly registered during TYPO3 initialization.