### PR TITLE
[BUGFIX] Allow request to register internal cache very early

### DIFF
--- a/Classes/Core/Core.php
+++ b/Classes/Core/Core.php
@@ -269,6 +269,8 @@ class Core implements SingletonInterface
      */
     public function getCacheService()
     {
+        $this->cacheService->registerInternalCache();
+
         return $this->cacheService;
     }
 

--- a/Classes/Core/Service/CacheService.php
+++ b/Classes/Core/Service/CacheService.php
@@ -49,8 +49,11 @@ class CacheService implements SingletonInterface
      */
     public function registerInternalCache()
     {
-        $this->getCacheManager()
-            ->setCacheConfigurations([self::CACHE_IDENTIFIER => $this->cacheOptions]);
+        $cacheManager = $this->getCacheManager();
+
+        if (false === $cacheManager->hasCache(self::CACHE_IDENTIFIER)) {
+            $cacheManager->setCacheConfigurations([self::CACHE_IDENTIFIER => $this->cacheOptions]);
+        }
     }
 
     /**


### PR DESCRIPTION
This commit fixes an issue, where a configuration object was constructed very early in TYPO3 request dispatch, for instance in TCA definition. The cache was not registered yet, and that would lead to an exception being thrown.

The cache is now registered any time it is accessed.