### PR TITLE
[FEATURE] Introduce support for common array object annotation

### DIFF
--- a/Classes/ConfigurationObjectMapper.php
+++ b/Classes/ConfigurationObjectMapper.php
@@ -261,17 +261,30 @@ class ConfigurationObjectMapper extends PropertyMapper
      */
     protected function getTypeConverter($source, $targetType, $configuration)
     {
-        $typeConverter = $this->findTypeConverter($source, $targetType, $configuration);
+        $typeConverter = null;
 
-        if ($typeConverter instanceof ExtbaseArrayConverter
-            || $this->parseCompositeType($targetType) === '\\ArrayObject'
-            || $this->parseCompositeType($targetType) === 'array'
-        ) {
-            $typeConverter = $this->objectManager->get(ArrayConverter::class);
+        /**
+         * @see \Romm\ConfigurationObject\Reflection\ReflectionService
+         */
+        if ('[]' === substr($targetType, -2)) {
+            $className = substr($targetType, 0, -2);
+
+            if (Core::get()->classExists($className)) {
+                $typeConverter = $this->objectManager->get(ArrayConverter::class);
+            }
         }
 
-        if ($typeConverter instanceof ObjectConverter) {
-            $typeConverter = $this->getObjectConverter();
+        if (!$typeConverter) {
+            $typeConverter = $this->findTypeConverter($source, $targetType, $configuration);
+
+            if ($typeConverter instanceof ExtbaseArrayConverter
+                || $this->parseCompositeType($targetType) === '\\ArrayObject'
+                || $this->parseCompositeType($targetType) === 'array'
+            ) {
+                $typeConverter = $this->objectManager->get(ArrayConverter::class);
+            } elseif ($typeConverter instanceof ObjectConverter) {
+                $typeConverter = $this->getObjectConverter();
+            }
         }
 
         if (!is_object($typeConverter) || !$typeConverter instanceof TypeConverterInterface) {

--- a/Classes/Reflection/ReflectionService.php
+++ b/Classes/Reflection/ReflectionService.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * 2017 Romain CANON <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 Configuration Object project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Romm\ConfigurationObject\Reflection;
+
+use Romm\ConfigurationObject\Core\Core;
+
+/**
+ * This class is used to handle the common array annotation: `\Some\Class[]`.
+ *
+ * Indeed, TYPO3 does only support annotations like: `\ArrayObject<\Some\Class>`
+ * but this is not well supported by IDEs.
+ */
+class ReflectionService extends \TYPO3\CMS\Extbase\Reflection\ReflectionService
+{
+    /**
+     * Will transform the annotation:
+     * `\Some\Class[]` -> `\ArrayObject<\Some\Class>
+     *
+     * The last one is supported by TYPO3. See class description for more
+     * information.
+     *
+     * @param array $varTags
+     * @return array
+     */
+    protected function handleArrayAnnotation(array $varTags)
+    {
+        foreach ($varTags as $key => $tag) {
+            if ('[]' === substr($tag, -2)) {
+                $class = substr($tag, 0, -2);
+
+                if (Core::get()->classExists($class)) {
+                    $varTags[$key] = "\\ArrayObject<$class>";
+                }
+            }
+        }
+
+        return $varTags;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPropertyTagsValues($className, $propertyName)
+    {
+        $result = parent::getPropertyTagsValues($className, $propertyName);
+
+        if (isset($result['var'])) {
+            $result['var'] = $this->handleArrayAnnotation($result['var']);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPropertyTagValues($className, $propertyName, $tag)
+    {
+        $result = parent::getPropertyTagValues($className, $propertyName, $tag);
+
+        if (isset($result['var'])) {
+            $result['var'] = $this->handleArrayAnnotation($result['var']);
+        }
+
+        return $result;
+    }
+}

--- a/Classes/TypeConverter/ArrayConverter.php
+++ b/Classes/TypeConverter/ArrayConverter.php
@@ -73,7 +73,16 @@ class ArrayConverter extends AbstractTypeConverter
      */
     public function getTypeOfChildProperty($targetType, $propertyName, PropertyMappingConfigurationInterface $configuration)
     {
-        $parsedTargetType = TypeHandlingUtility::parseType($targetType);
+        /**
+         * @see \Romm\ConfigurationObject\Reflection\ReflectionService
+         */
+        if ('[]' === substr($targetType, -2)) {
+            $parsedTargetType = [
+                'elementType' => substr($targetType, 0, -2)
+            ];
+        } else {
+            $parsedTargetType = TypeHandlingUtility::parseType($targetType);
+        }
 
         return $parsedTargetType['elementType'];
     }

--- a/Classes/Validation/ValidatorResolver.php
+++ b/Classes/Validation/ValidatorResolver.php
@@ -13,9 +13,12 @@
 
 namespace Romm\ConfigurationObject\Validation;
 
+use Romm\ConfigurationObject\Core\Core;
+use Romm\ConfigurationObject\Reflection\ReflectionService;
 use Romm\ConfigurationObject\Service\Items\MixedTypes\MixedTypesInterface;
 use Romm\ConfigurationObject\Validation\Validator\Internal\MixedTypeCollectionValidator;
 use Romm\ConfigurationObject\Validation\Validator\Internal\MixedTypeObjectValidator;
+use TYPO3\CMS\Extbase\Reflection\ReflectionService as ExtbaseReflectionService;
 use TYPO3\CMS\Extbase\Validation\Validator\CollectionValidator;
 use TYPO3\CMS\Extbase\Validation\Validator\ConjunctionValidator;
 
@@ -83,5 +86,13 @@ class ValidatorResolver extends \TYPO3\CMS\Extbase\Validation\ValidatorResolver
         }
 
         return $conjunctionValidator;
+    }
+
+    /**
+     * @param ExtbaseReflectionService $reflectionService
+     */
+    public function injectReflectionService(ExtbaseReflectionService $reflectionService)
+    {
+        $this->reflectionService = Core::get()->getObjectManager()->get(ReflectionService::class);
     }
 }

--- a/Documentation/01-Introduction/Index.rst
+++ b/Documentation/01-Introduction/Index.rst
@@ -91,7 +91,7 @@ Let's see what our previous example would look like with a configuration object:
         protected $name;
 
         /**
-         * @var \ArrayObject<MyVendor\MyExtensions\Model\Company\Employee>
+         * @var \MyVendor\MyExtensions\Model\Company\Employee[]
          */
         protected $employees;
     }

--- a/Documentation/03-Usage/Index.rst
+++ b/Documentation/03-Usage/Index.rst
@@ -42,7 +42,7 @@ Please note that a configuration object root class (first level of the tree) nee
         protected $name;
 
         /**
-         * @var \ArrayObject<MyVendor\MyExtension\Configuration\Employee>
+         * @var \MyVendor\MyExtension\Configuration\Employee[]
          */
         protected $employees;
     }
@@ -65,6 +65,27 @@ Please note that a configuration object root class (first level of the tree) nee
          */
         protected $email;
     }
+
+.. tip::
+
+    There are three ways to declare an array object property:
+
+    .. code-block:: php
+        :linenos:
+        :emphasize-lines: 2,6
+
+        /**
+         * @var \MyVendor\MyExtension\Configuration\Employee[]
+         *
+         * OR
+         *
+         * @var \ArrayObject<\MyVendor\MyExtension\Configuration\Employee>
+         *
+         * OR
+         *
+         * @var array<\MyVendor\MyExtension\Configuration\Employee>
+         */
+        protected $employees;
 
 -----
 

--- a/Documentation/04-Administration/Services/AvailableServices/ParentsService.rst
+++ b/Documentation/04-Administration/Services/AvailableServices/ParentsService.rst
@@ -51,7 +51,7 @@ Example
         use DefaultConfigurationObjectTrait;
 
         /**
-         * @var \ArrayObject<SubObject>
+         * @var SubObject[]
          */
         protected $subObjects;
 

--- a/Documentation/04-Administration/Services/AvailableServices/PersistenceService.rst
+++ b/Documentation/04-Administration/Services/AvailableServices/PersistenceService.rst
@@ -47,7 +47,7 @@ Example
         protected $boss;
 
         /**
-         * @var \ArrayObject<\TYPO3\CMS\Beuser\Domain\Model\BackendUser>
+         * @var \TYPO3\CMS\Beuser\Domain\Model\BackendUser[]
          */
         protected $employees;
 

--- a/Documentation/04-Administration/Services/AvailableServices/StoreConfigurationArrayService.rst
+++ b/Documentation/04-Administration/Services/AvailableServices/StoreConfigurationArrayService.rst
@@ -38,7 +38,7 @@ Example
         use DefaultConfigurationObjectTrait;
 
         /**
-         * @var \ArrayObject<SubObject>
+         * @var SubObject[]
          */
         protected $subObjects;
 

--- a/Documentation/04-Administration/Utilities/Index.rst
+++ b/Documentation/04-Administration/Utilities/Index.rst
@@ -50,7 +50,7 @@ The trait :php:`ArrayConversionTrait` provides the function ``toArray()`` which 
         use ArrayConversionTrait;
 
         /**
-         * @var \ArrayObject<SubObject>
+         * @var SubObject[]
          */
         protected $subObjects;
     }
@@ -86,7 +86,7 @@ In some cases, a sub-object of a configuration object can be stored in an array,
         use DefaultConfigurationObjectTrait;
 
         /**
-         * @var \ArrayObject<SubObject>
+         * @var SubObject[]
          */
         protected $subObjects;
 

--- a/Tests/Unit/TypeConverter/ArrayConverterTest.php
+++ b/Tests/Unit/TypeConverter/ArrayConverterTest.php
@@ -1,9 +1,11 @@
 <?php
 namespace Romm\ConfigurationObject\Tests\Unit\TypeConverter;
 
+use Romm\ConfigurationObject\Tests\Fixture\Company\Employee;
 use Romm\ConfigurationObject\Tests\Fixture\Model\DummyConfigurationObjectWithStoreArrayIndexTrait;
 use Romm\ConfigurationObject\Tests\Unit\AbstractUnitTest;
 use Romm\ConfigurationObject\TypeConverter\ArrayConverter;
+use TYPO3\CMS\Extbase\Property\PropertyMappingConfigurationInterface;
 
 class ArrayConverterTest extends AbstractUnitTest
 {
@@ -46,5 +48,31 @@ class ArrayConverterTest extends AbstractUnitTest
         $index = $dummyConfigurationObject->getArrayIndex();
 
         $this->assertEquals('foo', $index);
+    }
+
+    /**
+     * Checks that the three different ways of writing array object annotations
+     * are found:
+     * `\Some\Class[]`
+     * `ArrayObject<\Some\Class>`
+     * `array<\Some\Class>`
+     *
+     * @test
+     */
+    public function childPropertyTypesAreFound()
+    {
+        $configurationMock = $this->getMockBuilder(PropertyMappingConfigurationInterface::class)
+            ->getMock();
+
+        $arrayConverter = new ArrayConverter();
+
+        $type = $arrayConverter->getTypeOfChildProperty(Employee::class . '[]', 'foo', $configurationMock);
+        $this->assertEquals(Employee::class, $type);
+
+        $type = $arrayConverter->getTypeOfChildProperty(\ArrayObject::class . '<' . Employee::class . '>', 'foo', $configurationMock);
+        $this->assertEquals(Employee::class, $type);
+
+        $type = $arrayConverter->getTypeOfChildProperty('array<' . Employee::class . '>', 'foo', $configurationMock);
+        $this->assertEquals(Employee::class, $type);
     }
 }


### PR DESCRIPTION
Previously, when a property would be filled by an array of object, only two annotations were supported:

`\ArrayObject<\Some\Class>` and `array<\Some\Class>`

They are not user-friendly, and most of the time the array is a basic array (not an `ObjectStorage` for instance). The common annotation for this would be:

`\Some\Class[]` - which provides better IDE auto-completion, and has better readability.

This commit introduces support for this annotation, enjoy!