### PR TITLE
[FEATURE] Introduce `@mixedTypesResolver` tag annotation

### DIFF
--- a/Classes/ConfigurationObjectMapper.php
+++ b/Classes/ConfigurationObjectMapper.php
@@ -15,7 +15,6 @@ namespace Romm\ConfigurationObject;
 
 use Romm\ConfigurationObject\Core\Core;
 use Romm\ConfigurationObject\Core\Service\ReflectionService;
-use Romm\ConfigurationObject\Exceptions\ClassNotFoundException;
 use Romm\ConfigurationObject\Service\DataTransferObject\ConfigurationObjectConversionDTO;
 use Romm\ConfigurationObject\Service\DataTransferObject\GetTypeConverterDTO;
 use Romm\ConfigurationObject\Service\Event\ObjectConversionAfterServiceEventInterface;
@@ -27,7 +26,6 @@ use Romm\ConfigurationObject\Service\ServiceFactory;
 use Romm\ConfigurationObject\Service\ServiceInterface;
 use Romm\ConfigurationObject\TypeConverter\ArrayConverter;
 use Romm\ConfigurationObject\TypeConverter\ConfigurationObjectConverter;
-use Romm\Formz\Exceptions\InvalidOptionValueException;
 use TYPO3\CMS\Extbase\Error\Error;
 use TYPO3\CMS\Extbase\Property\Exception\TypeConverterException;
 use TYPO3\CMS\Extbase\Property\PropertyMapper;

--- a/Classes/Service/Items/MixedTypes/MixedTypesService.php
+++ b/Classes/Service/Items/MixedTypes/MixedTypesService.php
@@ -98,15 +98,15 @@ class MixedTypesService extends AbstractService
             $classReflection = ReflectionService::get()->getClassReflection($targetType);
             $propertyReflection = $classReflection->getProperty($propertyName);
 
-            if ($propertyReflection->isTaggedWith(MixedTypesService::PROPERTY_ANNOTATION_MIXED_TYPE)) {
-                $tag = $propertyReflection->getTagValues(MixedTypesService::PROPERTY_ANNOTATION_MIXED_TYPE);
+            if ($propertyReflection->isTaggedWith(self::PROPERTY_ANNOTATION_MIXED_TYPE)) {
+                $tag = $propertyReflection->getTagValues(self::PROPERTY_ANNOTATION_MIXED_TYPE);
                 $className = trim(end($tag));
 
                 if (false === Core::get()->classExists($className)) {
                     throw new ClassNotFoundException(
                         vsprintf(
                             'Class "%s" given as value for the tag "@%s" of the class property "%s::$%s" was not found.',
-                            [$className, MixedTypesService::PROPERTY_ANNOTATION_MIXED_TYPE, $targetType, $propertyName]
+                            [$className, self::PROPERTY_ANNOTATION_MIXED_TYPE, $targetType, $propertyName]
                         ),
                         1489155862
                     );
@@ -115,7 +115,7 @@ class MixedTypesService extends AbstractService
                         throw new InvalidOptionValueException(
                             vsprintf(
                                 'Class "%s" given as value for the tag "@%s" of the class property "%s::$%s" must implement the interface "%s".',
-                                [$className, MixedTypesService::PROPERTY_ANNOTATION_MIXED_TYPE, $targetType, $propertyName, MixedTypesInterface::class]
+                                [$className, self::PROPERTY_ANNOTATION_MIXED_TYPE, $targetType, $propertyName, MixedTypesInterface::class]
                             ),
                             1489156005
                         );

--- a/Classes/Service/Items/MixedTypes/MixedTypesService.php
+++ b/Classes/Service/Items/MixedTypes/MixedTypesService.php
@@ -82,7 +82,15 @@ class MixedTypesService extends AbstractService
         return true === array_key_exists(MixedTypesInterface::class, class_implements($className));
     }
 
-    public function checkMixedTypeAnnotationForProperty($targetType, $propertyName)
+    /**
+     * @param string $targetType
+     * @param string $propertyName
+     * @param string $isComposite
+     * @return null|string
+     * @throws ClassNotFoundException
+     * @throws InvalidOptionValueException
+     */
+    public function checkMixedTypeAnnotationForProperty($targetType, $propertyName, $isComposite)
     {
         $result = null;
 
@@ -113,7 +121,11 @@ class MixedTypesService extends AbstractService
                         );
                     }
 
-                    $result = $className . '[]';
+                    $result = $className;
+
+                    if (true === $isComposite) {
+                        $result .= '[]';
+                    }
                 }
             }
         }

--- a/Documentation/04-Administration/Services/AvailableServices/MixedTypesService.rst
+++ b/Documentation/04-Administration/Services/AvailableServices/MixedTypesService.rst
@@ -12,17 +12,69 @@ Mixed types service
 
 This service allows **properties types to be dynamically fetched**.
 
-For instance, in a configuration object which contains a list of employees, **every employee can have a different role**; in this case, roles can be **divided into PHP classes**. This service will allow the implementation of a **method which will be used to resolve which class should be used**. Take a look at the example below for more information.
+For instance, in a configuration object which contains a list of employees, **every employee can have a different role**; in this case, roles can be **divided into PHP classes**. This service will allow the implementation of a **method that will be called to resolve which class should be used**. Take a look at the example below for more information.
 
 Usage
 -----
 
 You can activate this service for a given configuration object by attaching it to the ``ServiceFactory`` in the static function ``getConfigurationObjectServices()``. Use the constant :php:`ServiceInterface::SERVICE_MIXED_TYPES` as an identifier for this service (see example below).
 
-You then have to implement the interface :php:`MixedTypesInterface` in every class which needs this feature, and write your own :php:`public static function getInstanceClassName(MixedTypesResolver $resolver)` implementation.
+You have two possibilities to use it on properties:
+
+- **Solution 1**: you can use the annotation ``@mixedTypesResolver`` on the property that needs it, filled with a class name that implements the interface :php:`MixedTypesInterface`.
+
+- **Solution 2**: the type of the variable can be the resolver class, for instance an abstract class.
+
+The resolver class has to implement the interface :php:`MixedTypesInterface`, and have its own :php:`public static function getInstanceClassName(MixedTypesResolver $resolver)` implementation.
 
 Example
 -------
+
+**Solution 1:**
+
+.. code-block:: php
+    :linenos:
+    :emphasize-lines: 7,25
+
+    class Configuration implements ConfigurationObjectInterface
+    {
+        use DefaultConfigurationObjectTrait;
+
+        /**
+         * @var FooInterface[]
+         * @mixedTypesResolver FooResolver
+         */
+        protected $foo;
+    }
+
+    class FooResolver implements MixedTypesInterface
+    {
+        /**
+         * @inheritdoc
+         */
+        public static function getInstanceClassName(MixedTypesResolver $resolver)
+        {
+            $data = $resolver->getData();
+
+            $type = ($data['type'] === 'foo')
+                ? Foo::class
+                : Bar::class;
+
+            $resolver->setObjectType($type);
+        }
+    }
+
+    class Foo implements FooInterface
+    {
+        // Some code...
+    }
+
+    class Bar implements FooInterface
+    {
+        // Some other code...
+    }
+
+**Solution 2:**
 
 .. code-block:: php
     :linenos:

--- a/Tests/Unit/ConfigurationObjectUnitTestUtility.php
+++ b/Tests/Unit/ConfigurationObjectUnitTestUtility.php
@@ -25,7 +25,6 @@ use TYPO3\CMS\Extbase\Property\TypeConverter\StringConverter;
 use TYPO3\CMS\Extbase\Reflection\ClassSchema;
 use TYPO3\CMS\Extbase\Reflection\ReflectionService;
 use TYPO3\CMS\Extbase\Service\EnvironmentService;
-use TYPO3\CMS\Extbase\Service\TypeHandlingService;
 use TYPO3\CMS\Extbase\Utility\ArrayUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
@@ -226,7 +225,6 @@ trait ConfigurationObjectUnitTestUtility
         } else {
             $reflectionService->injectObjectManager(Core::get()->getObjectManager());
         }
-        $mockedConfigurationObjectMapper->injectReflectionService($reflectionService);
 
         $mockedConfigurationObjectMapper->initializeObject();
 


### PR DESCRIPTION
This tag can be given to properties that need a mixed type resolver to detect their dynamic types. This allows the `@var` tag to be filled with the real type(s) of the values, making the getter/setter methods annotations coherent.